### PR TITLE
add JSON version

### DIFF
--- a/elements.json
+++ b/elements.json
@@ -1,0 +1,1896 @@
+[
+  {
+    "element": "a",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/text-level-semantics.html#the-a-element",
+    "description": "Anchor.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "abbr",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/text-level-semantics.html#the-abbr-element",
+    "description": "Abbreviation.",
+    "specs":[
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "access",
+    "link": "http://www.w3.org/TR/xhtml2/mod-access.html#edef_access_access",
+    "description": "Accessibility mapping.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "acronym",
+    "link": "http://www.w3.org/TR/html401/struct/text.html#edef-ACRONYM",
+    "description": "Acronym.",
+    "specs":[
+      "4.01",
+      "X1.0",
+      "X1.1"
+    ]
+  },
+  {
+    "element": "action",
+    "link": "http://www.w3.org/TR/xhtml2/mod-handler.html#edef_handler_action",
+    "description": "Action.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "addEventListener",
+    "link": "http://www.w3.org/TR/xhtml2/mod-handler.html#edef_handler_addEventListener",
+    "description": "Event-related.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "address",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/sections.html#the-address-element",
+    "description": "Author information.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "applet",
+    "link": "http://www.w3.org/TR/html401/struct/objects.html#edef-APPLET",
+    "description": "Java applet.",
+    "specs":[
+      "3.2",
+      "4.01",
+      "X1.0"
+    ]
+  },
+  {
+    "element": "area",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/the-map-element.html#the-area-element",
+    "description": "Client-side image map.",
+    "specs":[
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "article",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/sections.html#the-article-element",
+    "description": "“Independent” section.",
+    "specs":[
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "aside",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/sections.html#the-aside-element",
+    "description": "“Auxiliary” section.",
+    "specs":[
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "audio",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/the-video-element.html#the-audio-element",
+    "description": "Audio stream.",
+    "specs":[
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "b",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/text-level-semantics.html#the-b-element",
+    "description": "Bold text style.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "base",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/semantics.html#the-base-element",
+    "description": "Document base <abbr title=\"Uniform Resource Identifier\">URI</abbr>.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "basefont",
+    "link": "http://www.w3.org/TR/html401/present/graphics.html#edef-BASEFONT",
+    "description": "Base font size.",
+    "specs":[
+      "3.2",
+      "4.01",
+      "X1.0"
+    ]
+  },
+  {
+    "element": "bdi",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/text-level-semantics.html#the-bdi-element",
+    "description": "<abbr title=\"Internationalization\">I18N</abbr>: <abbr title=\"bi-directionality\">Bidi</abbr> isolation.",
+    "specs":[
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "bdo",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/text-level-semantics.html#the-bdo-element",
+    "description": "I18N: Bidi override.",
+    "specs":[
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "big",
+    "link": "http://www.w3.org/TR/html401/present/graphics.html#edef-BIG",
+    "description": "Large text style.",
+    "specs":[
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1"
+    ]
+  },
+  {
+    "element": "blockcode",
+    "link": "http://www.w3.org/TR/xhtml2/mod-structural.html#edef_structural_blockcode",
+    "description": "Code block.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "blockquote",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/grouping-content.html#the-blockquote-element",
+    "description": "Long quotation.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "body",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/sections.html#the-body-element",
+    "description": "Document body.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "br",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/text-level-semantics.html#the-br-element",
+    "description": "Forced line break.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "button",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/the-button-element.html#the-button-element",
+    "description": "Push button.",
+    "specs":[
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "canvas",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/the-canvas-element.html#the-canvas-element",
+    "description": "Bitmap canvas.",
+    "specs":[
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "caption",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/tabular-data.html#the-caption-element",
+    "description": "(Table) caption.",
+    "specs":[
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "center",
+    "link": "http://www.w3.org/TR/html401/present/graphics.html#edef-CENTER",
+    "description": "<code>&lt;div align=&quot;center&quot;&gt;</code>.",
+    "specs":[
+      "3.2",
+      "4.01",
+      "X1.0"
+    ]
+  },
+  {
+    "element": "cite",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/text-level-semantics.html#the-cite-element",
+    "description": "Citation.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "code",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/text-level-semantics.html#the-code-element",
+    "description": "Code fragment.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "col",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/tabular-data.html#the-col-element",
+    "description": "Table column.",
+    "specs":[
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "colgroup",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/tabular-data.html#the-colgroup-element",
+    "description": "Table column group.",
+    "specs":[
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "data",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/text-level-semantics.html#the-data-element",
+    "description": "Data with machine-readable equivalent.",
+    "specs":[
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "datalist",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/the-button-element.html#the-datalist-element",
+    "description": "Data list.",
+    "specs":[
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "dd",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/grouping-content.html#the-dd-element",
+    "description": "Definition description.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "del",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/edits.html#the-del-element",
+    "description": "Deleted text.",
+    "specs":[
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "delete",
+    "link": "http://www.w3.org/TR/xhtml2/mod-xforms.html#edef_xforms_delete",
+    "description": "Delete.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "details",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/interactive-elements.html#the-details-element",
+    "description": "Additional information.",
+    "specs":[
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "dfn",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/text-level-semantics.html#the-dfn-element",
+    "description": "Instance definition.",
+    "specs":[
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "di",
+    "link": "http://www.w3.org/TR/xhtml2/mod-list.html#edef_list_di",
+    "description": "Definition item.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "dialog",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/commands.html#the-dialog-element",
+    "description": "User interaction.",
+    "specs":[
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "dir",
+    "link": "http://www.w3.org/TR/html401/struct/lists.html#edef-DIR",
+    "description": "Directory list.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0"
+    ]
+  },
+  {
+    "element": "dispatch",
+    "link": "http://www.w3.org/TR/xhtml2/mod-xforms.html#edef_xforms_dispatch",
+    "description": "Dispatch.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "dispatchEvent",
+    "link": "http://www.w3.org/TR/xhtml2/mod-handler.html#edef_handler_dispatchEvent",
+    "description": "Dispatch event.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "div",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/grouping-content.html#the-div-element",
+    "description": "Generic container.",
+    "specs":[
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "dl",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/grouping-content.html#the-dl-element",
+    "description": "Definition list.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "dt",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/grouping-content.html#the-dt-element",
+    "description": "Definition term.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "em",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/text-level-semantics.html#the-em-element",
+    "description": "Emphasis.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "embed",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/the-iframe-element.html#the-embed-element",
+    "description": "Integration point.",
+    "specs":[
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "fieldset",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/the-button-element.html#the-fieldset-element",
+    "description": "Form control group.",
+    "specs":[
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "figcaption",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/grouping-content.html#the-figcaption-element",
+    "description": "Legend.",
+    "specs":[
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "figure",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/grouping-content.html#the-figure-element",
+    "description": "Paragraph with embedded content and caption.",
+    "specs":[
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "font",
+    "link": "http://www.w3.org/TR/html401/present/graphics.html#edef-FONT",
+    "description": "Local change to font.",
+    "specs":[
+      "3.2",
+      "4.01",
+      "X1.0"
+    ]
+  },
+  {
+    "element": "footer",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/sections.html#the-footer-element",
+    "description": "Section footer.",
+    "specs":[
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "form",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/forms.html#the-form-element",
+    "description": "Interactive form.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "frame",
+    "link": "http://www.w3.org/TR/html401/present/frames.html#edef-FRAME",
+    "description": "Subwindow.",
+    "specs":[
+      "4.01"
+    ]
+  },
+  {
+    "element": "frameset",
+    "link": "http://www.w3.org/TR/html401/present/frames.html#edef-FRAMESET",
+    "description": "Window subdivision.",
+    "specs":[
+      "4.01"
+    ]
+  },
+  {
+    "element": "group",
+    "link": "http://www.w3.org/TR/xhtml2/mod-xforms.html#edef_xforms_group",
+    "description": "Element group.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "h",
+    "link": "http://www.w3.org/TR/xhtml2/mod-structural.html#edef_structural_h",
+    "description": "Heading.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "h1",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/sections.html#the-h1-element",
+    "description": "Heading.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "h2",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/sections.html#the-h2-element",
+    "description": "Heading.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "h3",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/sections.html#the-h3-element",
+    "description": "Heading.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "h4",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/sections.html#the-h4-element",
+    "description": "Heading.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "h5",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/sections.html#the-h5-element",
+    "description": "Heading.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "h6",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/sections.html#the-h6-element",
+    "description": "Heading.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "head",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/semantics.html#the-head-element",
+    "description": "Document head.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "header",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/sections.html#the-header-element",
+    "description": "Section header.",
+    "specs":[
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "hgroup",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/sections.html#the-hgroup-element",
+    "description": "Section heading.",
+    "specs":[
+    ]
+  },
+  {
+    "element": "hr",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/grouping-content.html#the-hr-element",
+    "description": "Horizontal rule.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "html",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/semantics.html#the-html-element",
+    "description": "Document root.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "i",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/text-level-semantics.html#the-i-element",
+    "description": "Italic text style.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "iframe",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/the-iframe-element.html#the-iframe-element",
+    "description": "Inline subwindow.",
+    "specs":[
+      "4.01",
+      "X1.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "img",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/edits.html#the-img-element",
+    "description": "Embedded image.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "input",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/the-input-element.html#the-input-element",
+    "description": "Form control.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "ins",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/edits.html#the-ins-element",
+    "description": "Inserted text.",
+    "specs":[
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "insert",
+    "link": "http://www.w3.org/TR/xhtml2/mod-xforms.html#edef_xforms_insert",
+    "description": "Insert.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "isindex",
+    "link": "http://www.w3.org/TR/html401/interact/forms.html#edef-ISINDEX",
+    "description": "Single line prompt.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0"
+    ]
+  },
+  {
+    "element": "kbd",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/text-level-semantics.html#the-kbd-element",
+    "description": "Text to be entered.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "keygen",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/the-button-element.html#the-keygen-element",
+    "description": "Key generator.",
+    "specs":[
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "l",
+    "link": "http://www.w3.org/TR/xhtml2/mod-text.html#edef_text_l",
+    "description": "Line of text.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "label",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/forms.html#the-label-element",
+    "description": "Form field label.",
+    "specs":[
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "legend",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/the-button-element.html#the-legend-element",
+    "description": "Fieldset legend.",
+    "specs":[
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "li",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/grouping-content.html#the-li-element",
+    "description": "List item.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "link",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/semantics.html#the-link-element",
+    "description": "Media-independent link.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "listener",
+    "link": "http://www.w3.org/TR/xhtml2/mod-xml-events.html#edef_xml-events_listener",
+    "description": "Event-related.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "listing",
+    "link": "http://www.w3.org/TR/REC-html32#listing",
+    "description": "Listing.",
+    "specs":[
+      "2.0",
+      "3.2"
+    ]
+  },
+  {
+    "element": "load",
+    "link": "http://www.w3.org/TR/xhtml2/mod-xforms.html#edef_xforms_load",
+    "description": "Load.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "main",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/grouping-content.html#the-main-element",
+    "description": "Main content of document",
+    "specs":[
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "map",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/the-map-element.html#the-map-element",
+    "description": "Client-side image map.",
+    "specs":[
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "mark",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/text-level-semantics.html#the-mark-element",
+    "description": "Marked text.",
+    "specs":[
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "menu",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/interactive-elements.html#the-menu-element",
+    "description": "Menu list.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "5.1"
+    ]
+  },
+  {
+    "element": "menuitem",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/interactive-elements.html#the-menuitem-element",
+    "description": "User-invokable command.",
+    "specs":[
+      "5.1"
+    ]
+  },
+  {
+    "element": "message",
+    "link": "http://www.w3.org/TR/xhtml2/mod-xforms.html#edef_xforms_message",
+    "description": "Message.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "meta",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/semantics.html#the-meta-element",
+    "description": "Generic meta-information.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "meter",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/the-button-element.html#the-meter-element",
+    "description": "Scalar measurement.",
+    "specs":[
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "model",
+    "link": "http://www.w3.org/TR/xhtml2/mod-xforms.html#edef_xforms_model",
+    "description": "Model.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "nav",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/sections.html#the-nav-element",
+    "description": "Navigation links section.",
+    "specs":[
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "nextid",
+    "link": "http://www.w3.org/MarkUp/html-spec/html-spec_5.html#SEC5.2.6",
+    "description": "Anchor element name hint.",
+    "specs":[
+      "2.0"
+    ]
+  },
+  {
+    "element": "noframes",
+    "link": "http://www.w3.org/TR/html401/present/frames.html#edef-NOFRAMES",
+    "description": "Alternate container.",
+    "specs":[
+      "4.01",
+      "X1.0"
+    ]
+  },
+  {
+    "element": "noscript",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/scripting-1.html#the-noscript-element",
+    "description": "Alternate container.",
+    "specs":[
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "object",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/the-iframe-element.html#the-object-element",
+    "description": "Generic embedded object.",
+    "specs":[
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "ol",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/grouping-content.html#the-ol-element",
+    "description": "Ordered list.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "optgroup",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/the-button-element.html#the-optgroup-element",
+    "description": "Option group.",
+    "specs":[
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "option",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/the-button-element.html#the-option-element",
+    "description": "Selectable choice.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "output",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/the-button-element.html#the-output-element",
+    "description": "Output.",
+    "specs":[
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "p",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/grouping-content.html#the-p-element",
+    "description": "Paragraph.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "param",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/the-iframe-element.html#the-param-element",
+    "description": "Named property value.",
+    "specs":[
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "plaintext",
+    "link": "http://www.w3.org/TR/REC-html32#plaintext",
+    "description": "Plain text.",
+    "specs":[
+      "2.0",
+      "3.2"
+    ]
+  },
+  {
+    "element": "pre",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/grouping-content.html#the-pre-element",
+    "description": "Preformatted text.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "preventDefault",
+    "link": "http://www.w3.org/TR/xhtml2/mod-handler.html#edef_handler_preventDefault",
+    "description": "Event-related.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "progress",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/the-button-element.html#the-progress-element",
+    "description": "Progress of a task.",
+    "specs":[
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "q",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/text-level-semantics.html#the-q-element",
+    "description": "Short inline quotation.",
+    "specs":[
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "range",
+    "link": "http://www.w3.org/TR/xhtml2/mod-xforms.html#edef_xforms_range",
+    "description": "Range definition.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "rb",
+    "link": "http://www.w3.org/TR/ruby/#rb",
+    "description": "<a href=\"http://www.w3.org/TR/ruby/\">Ruby</a> base.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "rbc",
+    "link": "http://www.w3.org/TR/ruby/#rbc",
+    "description": "Ruby base container.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "rebuild",
+    "link": "http://www.w3.org/TR/xhtml2/mod-xforms.html#edef_xforms_rebuild",
+    "description": "Rebuild.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "recalculate",
+    "link": "http://www.w3.org/TR/xhtml2/mod-xforms.html#edef_xforms_recalculate",
+    "description": "Recalculate.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "refresh",
+    "link": "http://www.w3.org/TR/xhtml2/mod-xforms.html#edef_xforms_refresh",
+    "description": "Refresh.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "removeEventListener",
+    "link": "http://www.w3.org/TR/xhtml2/mod-handler.html#edef_handler_removeEventListener",
+    "description": "Event-related.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "repeat",
+    "link": "http://www.w3.org/TR/xhtml2/mod-xforms.html#edef_xforms_repeat",
+    "description": "Repeat.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "reset",
+    "link": "http://www.w3.org/TR/xhtml2/mod-xforms.html#edef_xforms_reset",
+    "description": "Reset.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "revalidate",
+    "link": "http://www.w3.org/TR/xhtml2/mod-xforms.html#edef_xforms_revalidate",
+    "description": "Revalidate.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "rp",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/text-level-semantics.html#the-rp-element",
+    "description": "Ruby parentheses.",
+    "specs":[
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "rt",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/text-level-semantics.html#the-rt-element",
+    "description": "Ruby text.",
+    "specs":[
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "rtc",
+    "link": "http://www.w3.org/TR/ruby/#rtc",
+    "description": "Ruby text container.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "ruby",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/text-level-semantics.html#the-ruby-element",
+    "description": "Ruby markup.",
+    "specs":[
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "s",
+    "link": "http://www.w3.org/TR/html401/present/graphics.html#edef-S",
+    "description": "Strike-through text style.",
+    "specs":[
+      "4.01",
+      "X1.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "samp",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/text-level-semantics.html#the-samp-element",
+    "description": "Sample output.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "script",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/scripting-1.html#the-script-element",
+    "description": "Script statements.",
+    "specs":[
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "secret",
+    "link": "http://www.w3.org/TR/xhtml2/mod-xforms.html#edef_xforms_secret",
+    "description": "Secret input.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "section",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/sections.html#the-section-element",
+    "description": "Document section.",
+    "specs":[
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "select",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/the-button-element.html#the-select-element",
+    "description": "Option selector.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "select1",
+    "link": "http://www.w3.org/TR/xhtml2/mod-xforms.html#edef_xforms_select1",
+    "description": "Single select.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "send",
+    "link": "http://www.w3.org/TR/xhtml2/mod-xforms.html#edef_xforms_send",
+    "description": "Send.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "separator",
+    "link": "http://www.w3.org/TR/xhtml2/mod-structural.html#edef_structural_separator",
+    "description": "Break.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "setfocus",
+    "link": "http://www.w3.org/TR/xhtml2/mod-xforms.html#edef_xforms_setfocus",
+    "description": "Set focus.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "setindex",
+    "link": "http://www.w3.org/TR/xhtml2/mod-xforms.html#edef_xforms_setindex",
+    "description": "Set index.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "setvalue",
+    "link": "http://www.w3.org/TR/xhtml2/mod-xforms.html#edef_xforms_setvalue",
+    "description": "Set value.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "small",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/text-level-semantics.html#the-small-element",
+    "description": "Small text style (HTML 5: small print).",
+    "specs":[
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "source",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/the-video-element.html#the-source-element",
+    "description": "Media resource.",
+    "specs":[
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "span",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/text-level-semantics.html#the-span-element",
+    "description": "Generic container.",
+    "specs":[
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "standby",
+    "link": "http://www.w3.org/TR/xhtml2/mod-object.html#edef_object_standby",
+    "description": "Message (while loading).",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "stopPropagation",
+    "link": "http://www.w3.org/TR/xhtml2/mod-handler.html#edef_handler_stopPropagation",
+    "description": "Event-related.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "strike",
+    "link": "http://www.w3.org/TR/html401/present/graphics.html#edef-STRIKE",
+    "description": "Strike-through text.",
+    "specs":[
+      "3.2",
+      "4.01",
+      "X1.0"
+    ]
+  },
+  {
+    "element": "strong",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/text-level-semantics.html#the-strong-element",
+    "description": "Strong emphasis (HTML 5: importance).",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "style",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/semantics.html#the-style-element",
+    "description": "Style info.",
+    "specs":[
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "sub",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/text-level-semantics.html#the-sub-element",
+    "description": "Subscript.",
+    "specs":[
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "submit",
+    "link": "http://www.w3.org/TR/xhtml2/mod-xforms.html#edef_xforms_submit",
+    "description": "Submit.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "summary",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/interactive-elements.html#the-summary-element",
+    "description": "Summary, caption, or legend.",
+    "specs":[
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "sup",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/text-level-semantics.html#the-sup-element",
+    "description": "Superscript.",
+    "specs":[
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "switch",
+    "link": "http://www.w3.org/TR/xhtml2/mod-xforms.html#edef_xforms_switch",
+    "description": "Selection.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "table",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/tabular-data.html#the-table-element",
+    "description": "Table.",
+    "specs":[
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "tbody",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/tabular-data.html#the-tbody-element",
+    "description": "Table body.",
+    "specs":[
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "td",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/tabular-data.html#the-td-element",
+    "description": "Table data cell.",
+    "specs":[
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "template",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/scripting-1.html#the-template-element",
+    "description": "HTML fragment declaration.",
+    "specs":[
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "textarea",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/the-button-element.html#the-textarea-element",
+    "description": "Multi-line text field.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "tfoot",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/tabular-data.html#the-tfoot-element",
+    "description": "Table footer.",
+    "specs":[
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "th",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/tabular-data.html#the-th-element",
+    "description": "Table header cell.",
+    "specs":[
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "thead",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/tabular-data.html#the-thead-element",
+    "description": "Table header.",
+    "specs":[
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "time",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/text-level-semantics.html#the-time-element",
+    "description": "Date and/or time.",
+    "specs":[
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "title",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/semantics.html#the-title-element",
+    "description": "Document title.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "tr",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/tabular-data.html#the-tr-element",
+    "description": "Table row.",
+    "specs":[
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "track",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/the-video-element.html#the-track-element",
+    "description": "Timed track.",
+    "specs":[
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "trigger",
+    "link": "http://www.w3.org/TR/xhtml2/mod-xforms.html#edef_xforms_trigger",
+    "description": "Trigger.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "tt",
+    "link": "http://www.w3.org/TR/html401/present/graphics.html#edef-TT",
+    "description": "Teletype text style.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1"
+    ]
+  },
+  {
+    "element": "u",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/text-level-semantics.html#the-u-element",
+    "description": "Underlined text style.",
+    "specs":[
+      "3.2",
+      "4.01",
+      "X1.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "ul",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/grouping-content.html#the-ul-element",
+    "description": "Unordered list.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "upload",
+    "link": "http://www.w3.org/TR/xhtml2/mod-xforms.html#edef_xforms_upload",
+    "description": "File upload.",
+    "specs":[
+      "X2.0"
+    ]
+  },
+  {
+    "element": "var",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/text-level-semantics.html#the-var-element",
+    "description": "Variable instance.",
+    "specs":[
+      "2.0",
+      "3.2",
+      "4.01",
+      "X1.0",
+      "X1.1",
+      "X2.0",
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "video",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/the-video-element.html#the-video-element",
+    "description": "Video or movie.",
+    "specs":[
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "wbr",
+    "link": "http://www.w3.org/html/wg/drafts/html/master/text-level-semantics.html#the-wbr-element",
+    "description": "Line break opportunity.",
+    "specs":[
+      "5",
+      "5.1"
+    ]
+  },
+  {
+    "element": "xmp",
+    "link": "http://www.w3.org/TR/REC-html32#xmp",
+    "description": "Preformatted text.",
+    "specs":[
+      "2.0",
+      "3.2"
+    ]
+  }
+]


### PR DESCRIPTION
For programmatically determining valid HTML elements, a JSON version might be useful. This pull request provides one.

Data structure: Array consisting of objects. Each object has the keys `element`, `link`, `description` (HTML) and `specs` (Array of strings). The spec names are abbreviated as much as possible/useful.

To do: The JSON is manually created from the HTML file. For maintenance this step should be automated in either direction.
