### PR TITLE
Add link to published site

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@ elements-of-html
 ================
 
 Elements of HTML per version
+
+This is the source code repository for the site located at http://w3c.github.io/elements-of-html/


### PR DESCRIPTION
There currently isn't any link to the published site, so users arriving at the repo don't know what the source code is for. Adding a link should provide the necessary context.